### PR TITLE
Adding media query for tablet filters [Finished #150687300]

### DIFF
--- a/carolina_herrera/style.css
+++ b/carolina_herrera/style.css
@@ -31,8 +31,10 @@
   display: none;
 }
 
-.bw-display-layer .bwt-index-filter-list.bwt-hidden {
+@media (min-width: 768px){
+  .bw-display-layer .bwt-index-filter-list.bwt-hidden {
   display: block !important;
+  }
 }
 
 .bwt-types-container, .bw-display-layer label.hidden, .bwt-upcoming-event-container, .bwt-index-store-events-and-services, .bwt-sub-nav.bwt-hide-on-mobile * {

--- a/carolina_herrera/style.css
+++ b/carolina_herrera/style.css
@@ -32,6 +32,9 @@
 }
 
 @media (min-width: 768px){
+  .bwt-index-filters-toggle {
+    display: none !important;
+  }
   .bw-display-layer .bwt-index-filter-list.bwt-hidden {
   display: block !important;
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150687300

Talked it over with Nik, they do want filters to be displayed (not collapsed), and removed filter toggle in tablet view. 

On mobile, filters are collapsable and filter display button works. 